### PR TITLE
changed ->update() backtick

### DIFF
--- a/src/PDOChainer/DBAL.php
+++ b/src/PDOChainer/DBAL.php
@@ -82,7 +82,7 @@ class DBAL
     function update($table, array $dataArr, array $whereArr = array(), $limit = 1){
         $fields = $params = $values = $where = array();
         foreach($dataArr as $data){
-            $fields[] = "`{$data[0]}' = :{$data[0]}";
+            $fields[] = "`{$data[0]}` = :{$data[0]}";
             $values[] = array(":{$data[0]}", $data[1], (isset($data[2]) ? $data[2] : \PDO::PARAM_STR));
         }
         $i = 0;


### PR DESCRIPTION
I was having a problem with the update function, and saw that it used

``` php
$fields[] = "`{$data[0]}' = :{$data[0]}";
```

and it needed to have the backtick ` instead of the regular quote ' after the first data[0] 
It kept throwing errors before then..
